### PR TITLE
Enable marginal scales testing

### DIFF
--- a/openfisca_dummy_country/dummy_taxbenefitsystem.py
+++ b/openfisca_dummy_country/dummy_taxbenefitsystem.py
@@ -19,5 +19,5 @@ class DummyTaxBenefitSystem(TaxBenefitSystem):
         TaxBenefitSystem.__init__(self, entities)
         self.Scenario = Scenario
         self.add_legislation_params(path_to_root_params)
-        self.add_legislation_params(path_to_crds_params, 'csg.activite')
+        self.add_legislation_params(path_to_crds_params, 'contribution_sociale')
         self.add_variables_from_directory(path_to_model_dir)

--- a/openfisca_dummy_country/model/model.py
+++ b/openfisca_dummy_country/model/model.py
@@ -165,14 +165,15 @@ class salaire_net(Variable):
         return salaire_brut * 0.8
 
 
-class csg(Variable):
+class contribution_sociale(Variable):
     column = FloatCol
     entity = Individu
-    label = u"CSG payées sur le salaire"
+    label = u"Contribution payée sur le salaire"
     definition_period = YEAR
 
     def function(individu, period, legislation):
-        taux = legislation(period).csg.activite.deductible.taux
         salaire_brut = individu('salaire_brut', period, options=[ADD])
+        bareme = legislation(period).contribution_sociale.salaire.bareme
 
-        return taux * salaire_brut
+        return bareme.calc(salaire_brut)
+

--- a/openfisca_dummy_country/parameters/param_root.xml
+++ b/openfisca_dummy_country/parameters/param_root.xml
@@ -1,40 +1,48 @@
 
 <NODE code="root">
-  <NODE code="csg" description="Contribution sociale généralisée (CSG)">
-    <NODE code="activite" description="Revenus d'activité">
-      <NODE code="deductible" description="CSG déductible">
-        <CODE code="taux" description="taux de la CSG déductible" format="percent">
-          <VALUE deb="2015-01-01" fin="2015-12-31" valeur=".06" />
-          <VALUE deb="1998-01-01" fin="2014-12-31" valeur=".051" />
-        </CODE>
-        <BAREME code="abattement" description="Abattement de la base de la CSG déductible">
-          <TRANCHE code="tranche0">
-            <TAUX>
-              <VALUE deb="1998-01-01" fin="2004-12-31" valeur=".05" />
-              <VALUE deb="2005-01-01" fin="2011-12-31" valeur=".03" />
-              <VALUE deb="2012-01-01" fin="2014-12-31" valeur=".0175" />
-            </TAUX>
-            <SEUIL>
-              <VALUE deb="1998-01-01" fin="2014-12-31" valeur="0" />
-            </SEUIL>
-          </TRANCHE>
-          <TRANCHE code="tranche1">
-            <SEUIL>
-              <VALUE deb="2011-01-01" fin="2014-12-31" valeur="4" />
-            </SEUIL>
-            <TAUX>
-              <VALUE deb="2011-01-01" fin="2014-12-31" valeur="0" />
-            </TAUX>
-          </TRANCHE>
-        </BAREME>
-      </NODE>
-    </NODE>
-  </NODE>
   <NODE code="impot">
     <CODE code="taux" description="taux d'impôt sur les salaires" format="percent">
       <VALUE deb="2016-01-01" fuzzy="true" valeur="0.35" />
       <VALUE deb="2015-01-01" fin="2015-12-31" valeur="0.32" />
       <VALUE deb="1998-01-01" fin="2014-12-31" valeur="0.3" />
     </CODE>
+  </NODE>
+  <NODE code="contribution_sociale" description="Contribution sociale progressive">
+    <NODE code="salaire" description="Contribution sur les salaires">
+      <BAREME code="bareme" description="Bareme progressif de contribution sociale sur les salaires">
+        <TRANCHE code="tranche0">
+          <SEUIL>
+            <VALUE deb="2013-01-01" fuzzy="true" valeur="0" />
+          </SEUIL>
+          <TAUX>
+            <VALUE deb="2017-01-01" fuzzy="true" valeur="0.02" />
+            <VALUE deb="2015-01-01" fin="2016-12-31" valeur="0.04" />
+            <VALUE deb="2013-01-01" fin="2014-12-31" valeur="0.03" />
+          </TAUX>
+        </TRANCHE>
+        <TRANCHE code="tranche1">
+          <SEUIL>
+            <VALUE deb="2017-01-01" fuzzy="true" valeur="6000" />
+            <VALUE deb="2016-01-01" fin="2016-12-31" valeur="12300" />
+            <VALUE deb="2015-01-01" fin="2015-12-31" valeur="12200" />
+            <VALUE deb="2014-01-01" fin="2014-12-31" valeur="12100" />
+            <VALUE deb="2013-01-01" fin="2013-12-31" valeur="12000" />
+          </SEUIL>
+          <TAUX>
+            <VALUE deb="2017-01-01" fuzzy="true" valeur="0.06" />
+            <VALUE deb="2015-01-01" fin="2016-12-31" valeur="0.12" />
+            <VALUE deb="2013-01-01" fin="2014-12-31" valeur="0.10" />
+          </TAUX>
+        </TRANCHE>
+        <TRANCHE code="tranche2">
+          <SEUIL>
+            <VALUE deb="2017-01-01" fuzzy="true" valeur="12400" />
+          </SEUIL>
+          <TAUX>
+            <VALUE deb="2017-01-01" fuzzy="true" valeur="0.12" />
+          </TAUX>
+        </TRANCHE>
+      </BAREME>
+    </NODE>
   </NODE>
 </NODE>

--- a/openfisca_dummy_country/parameters/param_root.xml
+++ b/openfisca_dummy_country/parameters/param_root.xml
@@ -1,12 +1,18 @@
-
 <NODE code="root">
   <NODE code="impot">
-    <CODE code="taux" description="taux d'impôt sur les salaires" format="percent">
+    <!-- A basic ongoing parameter -->
+    <CODE code="taux" description="Taux d'impôt sur les salaires" format="percent">
       <VALUE deb="2016-01-01" fuzzy="true" valeur="0.35" />
       <VALUE deb="2015-01-01" fin="2015-12-31" valeur="0.32" />
       <VALUE deb="1998-01-01" fin="2014-12-31" valeur="0.3" />
     </CODE>
+    <!-- A basic interrupted parameter -->
+    <CODE code="bouclier" description="Montant maximum de l'impôt" format="percent">
+      <VALUE deb="2009-01-01" fin="2011-12-31" valeur="0.6" />
+      <VALUE deb="2008-01-01" fin="2008-12-31" valeur="0.5" />
+    </CODE>
   </NODE>
+  <!-- A basic bareme -->
   <NODE code="contribution_sociale" description="Contribution sociale progressive">
     <NODE code="salaire" description="Contribution sur les salaires">
       <BAREME code="bareme" description="Bareme progressif de contribution sociale sur les salaires">

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Dummy-Country',
-    version = '0.1.1',
+    version = '0.1.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Connected to openfisca/openfisca-web-api#107

Replace `csg` by a progressive `contribution_sociale` to be able to test marginal scales.